### PR TITLE
映画検索クエリのfirstを必須に修正

### DIFF
--- a/app/graphql/generated.go
+++ b/app/graphql/generated.go
@@ -3459,7 +3459,7 @@ func (ec *executionContext) unmarshalInputMovieConnectionInput(ctx context.Conte
 		switch k {
 		case "first":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
-			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			data, err := ec.unmarshalNInt2int(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -4627,22 +4627,6 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 		return graphql.Null
 	}
 	res := graphql.MarshalBoolean(*v)
-	return res
-}
-
-func (ec *executionContext) unmarshalOInt2ᚖint(ctx context.Context, v interface{}) (*int, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := graphql.UnmarshalInt(v)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.SelectionSet, v *int) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	res := graphql.MarshalInt(*v)
 	return res
 }
 

--- a/app/graphql/models/models_gen.go
+++ b/app/graphql/models/models_gen.go
@@ -25,7 +25,7 @@ type MovieConnection struct {
 }
 
 type MovieConnectionInput struct {
-	First *int    `json:"first,omitempty"`
+	First int     `json:"first"`
 	After *string `json:"after,omitempty"`
 	Title *string `json:"title,omitempty"`
 }

--- a/app/graphql/resolver/converter/movie_converter.go
+++ b/app/graphql/resolver/converter/movie_converter.go
@@ -5,6 +5,9 @@ import (
 	domain "github.com/ichi-2049/filmie-server/internal/domain/models"
 )
 
+/*
+映画作品情報（カーソルページネーション）をdomainモデルからgqlモデルに変換する関数
+*/
 func ConvertMovieConnection(movieConnection *domain.MovieConnection) *gqlmodel.MovieConnection {
 	if movieConnection == nil {
 		return nil

--- a/app/graphql/resolver/movie_query.resolvers.go
+++ b/app/graphql/resolver/movie_query.resolvers.go
@@ -14,7 +14,7 @@ import (
 
 // Movies is the resolver for the movies field.
 func (r *queryResolver) Movies(ctx context.Context, input *gqlmodel.MovieConnectionInput) (*gqlmodel.MovieConnection, error) {
-	movieConnection, err := r.container.GetMovieService().GetMovieConnection(*input.First, input.After, input.Title)
+	movieConnection, err := r.container.GetMovieService().GetMovieConnection(input.First, input.After, input.Title)
 	if err != nil {
 		return nil, err
 	}

--- a/app/graphql/schema/queries/movie_query.graphql
+++ b/app/graphql/schema/queries/movie_query.graphql
@@ -3,7 +3,7 @@ extend type Query {
 }
 
 input MovieConnectionInput {
-  first: Int
+  first: Int!
   after: String
   title: String
 }

--- a/app/internal/application/services/movie_service.go
+++ b/app/internal/application/services/movie_service.go
@@ -5,6 +5,11 @@ import (
 	"github.com/ichi-2049/filmie-server/internal/domain/repositories"
 )
 
+const (
+	defaultFirst = 20
+	maxFirst     = 100
+)
+
 type MovieService struct {
 	movieRepo repositories.MovieRepository
 }
@@ -15,6 +20,16 @@ func NewMovieService(movieRepo repositories.MovieRepository) *MovieService {
 	}
 }
 
+/*
+映画作品情報をカーソルページネーションで取得する関数
+*/
 func (s *MovieService) GetMovieConnection(first int, after *string, title *string) (*domain.MovieConnection, error) {
+	// 最大取得件数を制限
+	if first <= 0 {
+		first = defaultFirst
+	}
+	if first > maxFirst {
+		first = maxFirst
+	}
 	return s.movieRepo.GetMovieConnection(first, after, title)
 }

--- a/app/internal/domain/repositories/movie_repository.go
+++ b/app/internal/domain/repositories/movie_repository.go
@@ -3,5 +3,9 @@ package repositories
 import domain "github.com/ichi-2049/filmie-server/internal/domain/models"
 
 type MovieRepository interface {
+	/*
+	映画作品情報をカーソルページネーションで取得する関数
+	タイトル（optional）で検索をかけ、人気順（降順）と映画ID（昇順）でソートする
+	*/
 	GetMovieConnection(first int, after *string, title *string) (*domain.MovieConnection, error)
 }

--- a/app/internal/infrastructure/repositoryImpl/movie_repository_impl.go
+++ b/app/internal/infrastructure/repositoryImpl/movie_repository_impl.go
@@ -26,6 +26,10 @@ type Cursor struct {
 	MovieID    int
 }
 
+/*
+映画作品情報をカーソルページネーションで取得する関数
+タイトル（optional）で検索をかけ、人気順（降順）と映画ID（昇順）でソートする
+*/
 func (r *MovieRepositoryImpl) GetMovieConnection(first int, after *string, title *string) (*domain.MovieConnection, error) {
 	// クエリのベースを作成
 	query := r.db.Model(&dao.Movie{})


### PR DESCRIPTION
## 概要
映画検索クエリのfirstを必須に修正し、件数制限処理をサービス層に追加。
および各層の関数のコメント追加